### PR TITLE
Do not ignore $enableval

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -210,9 +210,7 @@ dnl - check pygtk2
 AC_MSG_CHECKING([whether you enable pygtk2 anthy])
 AC_ARG_ENABLE(pygtk2-anthy,
               AS_HELP_STRING([--enable-pygtk2-anthy=no/yes],
-                             [Install pygtk2 anthy default=no]),
-              enable_pygtk2_anthy=yes,
-              enable_pygtk2_anthy=no)
+                             [Install pygtk2 anthy default=no]))
 AC_MSG_RESULT($enable_pygtk2_anthy)
 
 if test x"$enable_pygtk2_anthy" = xyes; then
@@ -287,9 +285,7 @@ dnl - check private png
 AC_MSG_CHECKING([if you install the private png file])
 AC_ARG_ENABLE(private-png,
               AS_HELP_STRING([--enable-private-png=no/yes],
-                             [Install ibus-anthy.png default=no]),
-              enable_private_png=yes,
-              enable_private_png=no)
+                             [Install ibus-anthy.png default=no]))
 AC_MSG_RESULT($enable_private_png)
 
 if test x"$enable_private_png" = xyes; then


### PR DESCRIPTION
configure.ac is ignoring $enableval, so that specifying --disable-\* won't work properly.
This patch just drop specified actions and configure do the default AC_ARG_ENABLE actions. The default action properly set $enableval
