### PR TITLE
Include anthy.i into distribution target

### DIFF
--- a/engine/Makefile.am
+++ b/engine/Makefile.am
@@ -118,7 +118,7 @@ test:
 
 EXTRA_DIST = \
 	$(engine_anthy_built_in_files) \
-	$(PYGTK2_ANTHY_RAW) \
+	anthy.i \
 	anthy.xml.in.in \
 	default.xml.in.in \
 	ibus-engine-anthy.in \


### PR DESCRIPTION
When pygth2 is disabled, PYGTK2_ANTHY_RAW is null, so that resulting tarball lacks "anthy.i". With such tarball, it failed to build with pygtk2 supported.
