### PR TITLE
Fix translations in appdata file

### DIFF
--- a/data/ibus-anthy.appdata.xml.in
+++ b/data/ibus-anthy.appdata.xml.in
@@ -5,16 +5,16 @@
   <project_license>GPL-2.0</project_license>
   <name>Anthy</name>
   <_summary>Japanese input method</_summary>
-  <_description>
-    <p>
+  <description>
+    <_p>
       The Anthy input method is designed for entering Japanese text.
-    </p>
-    <p>
+    <_/p>
+    <_p>
       Input methods are typing systems allowing users to input complex languages.
       They are necessary because these contain too many characters to simply be laid
       out on a traditional keyboard.
-    </p>
-  </_description>
+    <_/p>
+  </description>
   <url type="homepage">https://github.com/ibus/ibus/wiki</url>
   <url type="bugtracker">https://github.com/ibus/ibus-anthy/issues</url>
   <url type="help">https://github.com/ibus/ibus/wiki/FAQ</url>


### PR DESCRIPTION
ibus-anthy 1.5.9's appdata file is broken on Ubuntu 17.04 Beta.

In gnome-software the ibus-anthy description is in Ukrainian.

http://appstream.ubuntu.com/zesty/main/issues/ibus-anthy.html

Compare with gedit's [appstream](https://git.gnome.org/browse/gedit/tree/data/org.gnome.gedit.appdata.xml.in) file.