### PR TITLE
Migrate to gettext / drop intltool

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,19 +1,39 @@
 #!/bin/sh
-set -e
-set -x
+# Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-autopoint --force || exit 1
-libtoolize --automake --copy --force || exit 1
-intltoolize --copy --force || exit 1
-aclocal -I m4 --force || exit 1
-autoheader --force || exit 1
-automake --add-missing --copy --force || exit 1
-autoconf --force || exit 1
+olddir=$(pwd)
 
-if `echo "$@" | grep -q CFLAGS > /dev/null` ; then
-    ./configure "$@" || exit 1
+cd "$srcdir"
+
+(test -f configure.ac) || {
+        echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
+        exit 1
+}
+
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
+
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+        echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+        echo "*** If you wish to pass any to it, please specify them on the" >&2
+        echo "*** '$0' command line." >&2
+        echo "" >&2
+fi
+
+aclocal --install || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+        $srcdir/configure "$@" || exit 1
+
+        if [ "$1" = "--help" ]; then
+                exit 0
+        else
+                echo "Now type 'make' to compile $PKG_NAME" || exit 1
+        fi
 else
-    CFLAGS=${CFLAGS-"-Wall -Werror -Wformat -Werror=format-security"}
-    CXXFLAGS="$CFLAGS"
-    ./configure "$@" CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" || exit 1
+        echo "Skipping configure process."
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,6 @@ AM_PROG_CC_C_O
 AC_PROG_CXX
 AC_HEADER_STDC
 LT_INIT
-IT_PROG_INTLTOOL([0.41.1])
 
 dnl - For dislpay Date
 m4_define(ibus_datedisplay,
@@ -412,14 +411,19 @@ AC_SUBST(LT_VERSION_INFO)
 dnl - define GETTEXT_* variables
 GETTEXT_PACKAGE=ibus-anthy
 AC_SUBST(GETTEXT_PACKAGE)
-AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Define to the read-only architecture-independent data directory.])
 
+AC_DEFINE_UNQUOTED(
+  GETTEXT_PACKAGE, "$GETTEXT_PACKAGE",
+    [Define to the read-only architecture-independent data directory.]
+)
+
+AM_GNU_GETTEXT_VERSION([0.19.8])
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION(0.16.1)
 
 
 dnl - OUTPUT files
-AC_CONFIG_FILES([ po/Makefile.in
+AC_CONFIG_FILES([
+po/Makefile.in
 Makefile
 ibus-anthy.spec
 data/Makefile

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -32,26 +32,21 @@ dictsdir = $(pkgdatadir)/dicts
 # http://www.freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html
 # https://blogs.gnome.org/hughsie/2016/01/25/appdata-and-the-gettext-domain/
 metainfo_in_files = ibus-anthy.appdata.xml.in
-metainfo_inter_files = $(metainfo_in_files:.xml.in=.xml)
 metainfo_DATA = org.freedesktop.ibus.engine.anthy.metainfo.xml
 metainfodir=$(datadir)/metainfo
-@INTLTOOL_XML_RULE@
 
 schemas_in_files = org.freedesktop.ibus.engine.anthy.gschema.xml.in
 schemas_DATA = $(schemas_in_files:.xml.in=.xml)
 schemasdir = $(datadir)/glib-2.0/schemas
 
 CLEANFILES = \
-        $(metainfo_inter_files) \
         $(metainfo_DATA) \
         $(schemas_DATA) \
         emoji.t \
         $(NULL)
 
-$(metainfo_DATA): $(metainfo_inter_files)
-	mv $< $@
-	ln -s $@ $<
-	touch -m $@
+$(metainfo_DATA): $(metainfo_in_files) Makefile
+	$(AM_V_GEN)$(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
 $(schemas_DATA): $(schemas_in_files)
 	$(SED) -e "s|\@ANTHY_ZIPCODE_FILE\@|$(ANTHY_ZIPCODE_FILE)|g" \

--- a/data/ibus-anthy.appdata.xml.in
+++ b/data/ibus-anthy.appdata.xml.in
@@ -4,16 +4,16 @@
   <metadata_license>GFDL-1.3</metadata_license>
   <project_license>GPL-2.0</project_license>
   <name>Anthy</name>
-  <_summary>Japanese input method</_summary>
+  <summary>Japanese input method</summary>
   <description>
-    <_p>
+    <p>
       The Anthy input method is designed for entering Japanese text.
-    </_p>
-    <_p>
+    </p>
+    <p>
       Input methods are typing systems allowing users to input complex languages.
       They are necessary because these contain too many characters to simply be laid
       out on a traditional keyboard.
-    </_p>
+    </p>
   </description>
   <url type="homepage">https://github.com/ibus/ibus/wiki</url>
   <url type="bugtracker">https://github.com/ibus/ibus-anthy/issues</url>

--- a/ibus-anthy.spec.in
+++ b/ibus-anthy.spec.in
@@ -3,7 +3,6 @@
 
 %define sub_version                     1.0
 %define require_ibus_version            1.4.2
-%define require_intltool_version        0.41.1
 
 Name:       @PACKAGE_NAME@
 Version:    @PACKAGE_VERSION@
@@ -20,7 +19,6 @@ BuildRequires:  anthy-devel
 BuildRequires:  glib2-devel
 BuildRequires:  gettext-devel
 BuildRequires:  ibus
-BuildRequires:  intltool >= %require_intltool_version
 BuildRequires:  libtool
 BuildRequires:  pkgconfig
 BuildRequires:  gobject-introspection-devel

--- a/m4/Makefile.am
+++ b/m4/Makefile.am
@@ -22,4 +22,12 @@
 
 EXTRA_DIST = \
     as-version.m4 \
+    gettext.m4 \
+    iconv.m4 \
+    lib-ld.m4 \
+    lib-link.m4 \
+    lib-prefix.m4 \
+    nls.m4 \
+    po.m4 \
+    progtest.m4 \
     $(NULL)

--- a/po/Makevars
+++ b/po/Makevars
@@ -8,7 +8,7 @@ subdir = po
 top_builddir = ..
 
 # These options get passed to xgettext.
-XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
+XGETTEXT_OPTIONS = --from-code=UTF-8 --keyword=_ --keyword=N_ --keyword=C_:1c,2 --keyword=NC_:1c,2 --keyword=g_dngettext:2,3 --add-comments --keyword=Name --keyword=Comment --keyword
 
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
@@ -19,6 +19,13 @@ XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
 # the public domain; in this case the translators are expected to disclaim
 # their copyright.
 COPYRIGHT_HOLDER = Peng Huang <shawn.p.huang@gmail.com>
+
+# This tells whether or not to prepend "GNU " prefix to the package
+# name that gets inserted into the header of the $(DOMAIN).pot file.
+# Possible values are "yes", "no", or empty.  If it is empty, try to
+# detect it automatically by scanning the files in $(top_srcdir) for
+# "GNU packagename" string.
+PACKAGE_GNU = no
 
 # This is the email address or URL to which the translators shall report
 # bugs in the untranslated strings:
@@ -39,3 +46,33 @@ MSGID_BUGS_ADDRESS = https://github.com/ibus/ibus-anthy/issues
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.
 EXTRA_LOCALE_CATEGORIES =
+
+# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
+# context.  Possible values are "yes" and "no".  Set this to yes if the
+# package uses functions taking also a message context, like pgettext(), or
+# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
+USE_MSGCTXT = yes
+
+# These options get passed to msgmerge.
+# Useful options are in particular:
+#   --previous            to keep previous msgids of translated messages,
+#   --quiet               to reduce the verbosity.
+MSGMERGE_OPTIONS =
+
+# These options get passed to msginit.
+# If you want to disable line wrapping when writing PO files, add
+# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
+# MSGINIT_OPTIONS.
+MSGINIT_OPTIONS =
+
+# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
+# has changed.  Possible values are "yes" and "no".  Set this to no if
+# the POT file is checked in the repository and the version control
+# program ignores timestamps.
+PO_DEPENDS_ON_POT = no
+
+# This tells whether or not to forcibly update $(DOMAIN).pot and
+# regenerate PO files on "make dist".  Possible values are "yes" and
+# "no".  Set this to no if the POT file and PO files are maintained
+# externally.
+DIST_DEPENDS_ON_UPDATE_PO = no

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -10,8 +10,8 @@ engine/python3/factory.py
 setup/python2/anthyprefs.py
 setup/python2/ibus-setup-anthy.desktop.in.in
 setup/python2/main.py
-[type: gettext/glade]setup/python2/setup.ui
+setup/python2/setup.ui
 setup/python3/anthyprefs.py
 setup/python3/ibus-setup-anthy.desktop.in.in
 setup/python3/main.py
-[type: gettext/glade]setup/python3/setup.ui
+setup/python3/setup.ui

--- a/setup/python2/Makefile.am
+++ b/setup/python2/Makefile.am
@@ -33,7 +33,8 @@ $(desktop_in_files): %.desktop.in: %.desktop.in.in Makefile
 desktopdir=$(datadir)/applications
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 
-@INTLTOOL_DESKTOP_RULE@
+$(desktop_DATA): $(desktop_in_files) Makefile
+	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 BUILT_SOURCES = \
 	_config.py \

--- a/setup/python2/ibus-setup-anthy.desktop.in.in
+++ b/setup/python2/ibus-setup-anthy.desktop.in.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
-_Name=IBus Anthy Setup
-_Comment=Set up IBus Anthy engine
+Name=IBus Anthy Setup
+Comment=Set up IBus Anthy engine
 Exec=@libexecdir@/ibus-setup-anthy
 Icon=ibus-anthy
 NoDisplay=true

--- a/setup/python3/Makefile.am
+++ b/setup/python3/Makefile.am
@@ -31,9 +31,10 @@ $(desktop_in_files): %.desktop.in: %.desktop.in.in Makefile
 	       $< > $@.tmp && mv $@.tmp $@
 
 desktopdir=$(datadir)/applications
-desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
+desktop_DATA = ibus-setup-anthy.desktop
 
-@INTLTOOL_DESKTOP_RULE@
+$(desktop_DATA): $(desktop_in_files) Makefile
+	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 BUILT_SOURCES = \
 	_config.py \

--- a/setup/python3/ibus-setup-anthy.desktop.in.in
+++ b/setup/python3/ibus-setup-anthy.desktop.in.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
-_Name=IBus Anthy Setup
-_Comment=Set up IBus Anthy engine
+Name=IBus Anthy Setup
+Comment=Set up IBus Anthy engine
 Exec=@libexecdir@/ibus-setup-anthy
 Icon=ibus-anthy
 NoDisplay=true


### PR DESCRIPTION
Current `ibus-anthy` build system relies on `intltool` but it's deprecated. This patch ports the build scripts to recent gettext:

https://wiki.gnome.org/Initiatives/GnomeGoals/GettextMigration

Fixes https://github.com/ibus/ibus-anthy/issues/11.