### PR TITLE
Add the escape_to_latin command as a vi-cooperative cancel

### DIFF
--- a/engine/python3/engine.py
+++ b/engine/python3/engine.py
@@ -2315,6 +2315,20 @@ class Engine(IBus.EngineSimple):
             self.__invalidate()
             return True
 
+    def __cmd_escape_to_latin(self, keyval, state):
+        """
+        Vi-cooperative variant of cancel_all. When Vi users press Escape, they
+        expect to return to Normal mode where an IME would not make sense. This
+        command automatically switches back to Latin when sending Escape. When
+        converting, Escape will cancel the conversion instead.
+        """
+        if self._chk_mode('0'):
+            if Engine.__input_mode != INPUT_MODE_LATIN:
+                self.__cmd_latin_mode(keyval, state)
+            return False
+        else:
+            return self.__cmd_cancel_all(keyval, state)
+
     def __cmd_reconvert(self, keyval, state):
         if not self.__preedit_ja_string.is_empty():
             # if user has inputed some chars

--- a/setup/python3/anthyprefs.py
+++ b/setup/python3/anthyprefs.py
@@ -269,6 +269,7 @@ _cmd_keys = [
     'predict',
     'cancel',
     'cancel_all',
+    'escape_to_latin',
     'reconvert',
 #    'do_nothing',
 


### PR DESCRIPTION
When writing Japanese in Vim, everytime I switch from Insert mode back to
Normal mode, I need to also switch back the IBus input mode to Latin or else
Vim won’t take any of my input. This is kind fo annoying as key sequences like
`<Esc>:w` easily get wired into muscle memory.

For comparison, uim has got a vi-cooperative mode for that use case. See
<https://blog.myon.info/entry/2014/04/14/entry/> for illustration.

Here’s a new command which, when converting, behaves like cancel, but otherwise
switches to Latin and sends the Escape key. To make IBus vi-cooperative, a user
can map the Escape key to escape_to_latin instead of cancel.