### PR TITLE
Fix sticky keys for thumb shift mode

### DIFF
--- a/engine/python2/engine.py
+++ b/engine/python2/engine.py
@@ -247,6 +247,8 @@ class Engine(IBus.EngineSimple):
         self._H = 0
         self._RMM = 0
         self._RSS = 0
+        self._MS = 0 # modifier state
+        self._CM = 0 # command memory
         if self.__idle_id != 0:
             GLib.source_remove(self.__idle_id)
             self.__idle_id = 0
@@ -1827,9 +1829,8 @@ class Engine(IBus.EngineSimple):
                 return ret
             except:
                 pass
-
-        def cmd_exec(keyval, state=0):
-            key = self._mk_key(keyval, state)
+        
+        def __cmd_exec(key, keyval, state):
             for cmd in self.__keybind.get(key, []):
                 if config.DEBUG:
                     print 'cmd =', cmd
@@ -1839,6 +1840,30 @@ class Engine(IBus.EngineSimple):
                 except Exception as err:
                     printerr('Error command: %s: %s' % (cmd, str(err)))
             return False
+
+        def cmd_exec(keyval, state=0):
+            key = self._mk_key(keyval, state)
+            pair = eval(key)
+            self._MS = pair[0]
+            self._CM = pair[1]
+            return __cmd_exec(key, keyval, state)
+        
+        def cmd_term(keyval, state=0):
+            if self._MS == 0 and self._CM == 0:
+                return False
+
+            key = self._mk_key(keyval, state)
+            pair = eval(key)
+
+            prev_keyval = self._CM | IBus.ModifierType.RELEASE_MASK
+            prev_state = self._MS | IBus.ModifierType.RELEASE_MASK
+            prev_key = repr([int(prev_state), int(prev_keyval)])
+
+            self._MS = 0
+            self._CM = 0
+
+            __cmd_exec(prev_key, prev_keyval, prev_state)
+            return __cmd_exec(key, pair[1], pair[0])
 
         def RS():
             return self.__thumb.get_rs()
@@ -1874,6 +1899,12 @@ class Engine(IBus.EngineSimple):
                 self._RSS = 0
             elif keyval == self._RMM:
                 self._RMM = 0
+            elif keyval not in self.__thumb.get_chars() or state != 0:
+                if cmd_term(keyval, state):
+                    return True
+                elif not self.__preedit_ja_string.is_empty():
+                    return True
+                return False
         else:
             if keyval in [LS(), RS()] and state == 0:
                 if self._SS:

--- a/engine/python2/engine.py
+++ b/engine/python2/engine.py
@@ -1829,8 +1829,9 @@ class Engine(IBus.EngineSimple):
                 return ret
             except:
                 pass
-        
-        def __cmd_exec(key, keyval, state):
+
+        def __cmd_exec(pair, keyval, state):
+            key = repr(pair)
             for cmd in self.__keybind.get(key, []):
                 if config.DEBUG:
                     print 'cmd =', cmd
@@ -1842,28 +1843,26 @@ class Engine(IBus.EngineSimple):
             return False
 
         def cmd_exec(keyval, state=0):
-            key = self._mk_key(keyval, state)
-            pair = eval(key)
+            pair = self._adjust_for_shift(keyval, state)
             self._MS = pair[0]
             self._CM = pair[1]
-            return __cmd_exec(key, keyval, state)
-        
+            return __cmd_exec(pair, keyval, state)
+
         def cmd_term(keyval, state=0):
             if self._MS == 0 and self._CM == 0:
                 return False
 
-            key = self._mk_key(keyval, state)
-            pair = eval(key)
+            pair = self._adjust_for_shift(keyval, state)
 
             prev_keyval = self._CM | IBus.ModifierType.RELEASE_MASK
             prev_state = self._MS | IBus.ModifierType.RELEASE_MASK
-            prev_key = repr([int(prev_state), int(prev_keyval)])
+            prev_pair = [int(prev_state), int(prev_keyval)]
 
             self._MS = 0
             self._CM = 0
 
-            __cmd_exec(prev_key, prev_keyval, prev_state)
-            return __cmd_exec(key, pair[1], pair[0])
+            __cmd_exec(prev_pair, prev_keyval, prev_state)
+            return __cmd_exec(pair, pair[1], pair[0])
 
         def RS():
             return self.__thumb.get_rs()

--- a/engine/python3/engine.py
+++ b/engine/python3/engine.py
@@ -1771,6 +1771,11 @@ class Engine(IBus.EngineSimple):
 
     @staticmethod
     def _mk_key(keyval, state):
+        pair = Engine._adjust_for_shift(keyval, state)
+        return repr(pair)
+
+    @staticmethod
+    def _adjust_for_shift(keyval, state):
         if state & (IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.MOD1_MASK):
             if keyval < 0xff and \
                chr(keyval) in '!"#$%^\'()*+,-./:;<=>?@[\\]^_`{|}~':
@@ -1778,7 +1783,7 @@ class Engine(IBus.EngineSimple):
             elif IBus.KEY_a <= keyval <= IBus.KEY_z:
                 keyval -= (IBus.KEY_a - IBus.KEY_A)
 
-        return repr([int(state), int(keyval)])
+        return [int(state), int(keyval)]
 
     def __process_key_event(self, obj, keyval, keycode, state):
         try:
@@ -1824,8 +1829,9 @@ class Engine(IBus.EngineSimple):
                 return ret
             except:
                 pass
-        
-        def __cmd_exec(key, keyval, state):
+
+        def __cmd_exec(pair, keyval, state):
+            key = repr(pair)
             for cmd in self.__keybind.get(key, []):
                 if config.DEBUG:
                     print('cmd =', cmd)
@@ -1837,28 +1843,26 @@ class Engine(IBus.EngineSimple):
             return False
 
         def cmd_exec(keyval, state=0):
-            key = self._mk_key(keyval, state)
-            pair = eval(key)
+            pair = self._adjust_for_shift(keyval, state)
             self._MS = pair[0]
             self._CM = pair[1]
-            return __cmd_exec(key, keyval, state)
+            return __cmd_exec(pair, keyval, state)
 
         def cmd_term(keyval, state=0):
             if self._MS == 0 and self._CM == 0:
                 return False
 
-            key = self._mk_key(keyval, state)
-            pair = eval(key)
+            pair = self._adjust_for_shift(keyval, state)
 
             prev_keyval = self._CM | IBus.ModifierType.RELEASE_MASK
             prev_state = self._MS | IBus.ModifierType.RELEASE_MASK
-            prev_key = repr([int(prev_state), int(prev_keyval)])
+            prev_pair = [int(prev_state), int(prev_keyval)]
 
             self._MS = 0
             self._CM = 0
 
-            __cmd_exec(prev_key, prev_keyval, prev_state)
-            return __cmd_exec(key, pair[1], pair[0])
+            __cmd_exec(prev_pair, prev_keyval, prev_state)
+            return __cmd_exec(pair, pair[1], pair[0])
 
         def RS():
             return self.__thumb.get_rs()


### PR DESCRIPTION
**Symptom**
Given that:

- typing method is set to thumb shift mode
- input mode is not set to any Latin mode
- a text field is in focus
- a user has pressed once a key not included in the thumb shift key map, mostly command keys e.g.:
  - Backspace
  - Return (Enter)
  - Delete
  - Arrow Keys

When the user releases the key
Then the user sees that the key is being pressed forever (until esc is pressed or the user switches away from Anthy)

**Expected**
Given that:

- typing method is set to thumb shift mode
- input mode is not set to any Latin mode
- a text field is in focus
- a user has pressed once a key not included in the thumb shift key map, mostly command keys e.g.:
  - Backspace
  - Return (Enter)
  - Delete
  - Arrow Keys

When the user releases the key
Then the user sees that the key press does not automatically repeat itself in the text field

**Root Cause**
For keys that are neither thumb shift keys nor text keys, only the key press is processed. The key release is ignored by `__process_key_event_thumb()`. 

For illustration, please compare the if statements between the pressed handling and the released handling in engine/python3/engine.py.

Key Release:

```python
if state & IBus.ModifierTypes.RELEASE_MASK:
    # ... timer logic omitted
    if keyval in [RS(), LS()]:
        # ... omitted
    elif keyval == self._RMM:
        # ... omitted
```

Key Press:

```python
if state & IBus.ModifierTypes.RELEASE_MASK:
    # ... omitted (quoted above)
else:
    if keyval in [RS(), LS()] and state == 0:
        # ... omitted
    elif keyval in self.__thumb().get_chars() and state == 0:
        # ... omitted
    else:
        # ... timer logic omitted
        if cmd_exec(keyval, state): # <--- processes command key press
            return True
        # ... omitted
```

Hopefully this comparison is clear enough to show that `cmd_exec()` does not have a corresponding key release action.

**Solution**
Steps:
1. Store every non-thumb-shift, non-text key press
2. When handling non-thumb-shift, non-text key releases,
    a. fire release for the previous key press (if present)
    b. reset the key press storage
    c. hand the current key release back to IBus

**Remarks**
Please feel free to let me know about any practice that I should follow for this project.