### PR TITLE
Add super key support for thumb shift mode

### DIFF
--- a/engine/python2/engine.py
+++ b/engine/python2/engine.py
@@ -1855,6 +1855,7 @@ class Engine(IBus.EngineSimple):
         state = state & (IBus.ModifierType.SHIFT_MASK |
                          IBus.ModifierType.CONTROL_MASK |
                          IBus.ModifierType.MOD1_MASK |
+                         IBus.ModifierType.MOD4_MASK |
                          IBus.ModifierType.RELEASE_MASK)
 
         if keyval in KP_Table and self.__prefs.get_value('common',
@@ -1923,7 +1924,9 @@ class Engine(IBus.EngineSimple):
                 if cmd_exec(keyval, state):
                     return True
                 elif 0x21 <= keyval <= 0x7e and state & \
-                        (IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.MOD1_MASK) == 0:
+                        (IBus.ModifierType.CONTROL_MASK |
+                         IBus.ModifierType.MOD1_MASK |
+                         IBus.ModifierType.MOD4_MASK) == 0:
                     if state & IBus.ModifierType.SHIFT_MASK:
                         insert(self.__thumb.get_shift_char(keyval, unichr(keyval)))
                     elif self._SS == 0:

--- a/engine/python2/engine.py
+++ b/engine/python2/engine.py
@@ -1847,6 +1847,7 @@ class Engine(IBus.EngineSimple):
         state = state & (IBus.ModifierType.SHIFT_MASK |
                          IBus.ModifierType.CONTROL_MASK |
                          IBus.ModifierType.MOD1_MASK |
+                         IBus.ModifierType.MOD4_MASK |
                          IBus.ModifierType.RELEASE_MASK)
 
         if keyval in KP_Table and self.__prefs.get_value('common',
@@ -1915,7 +1916,9 @@ class Engine(IBus.EngineSimple):
                 if cmd_exec(keyval, state):
                     return True
                 elif 0x21 <= keyval <= 0x7e and state & \
-                        (IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.MOD1_MASK) == 0:
+                        (IBus.ModifierType.CONTROL_MASK |
+                         IBus.ModifierType.MOD1_MASK |
+                         IBus.ModifierType.MOD4_MASK) == 0:
                     if state & IBus.ModifierType.SHIFT_MASK:
                         insert(self.__thumb.get_shift_char(keyval, unichr(keyval)))
                     elif self._SS == 0:

--- a/engine/python2/engine.py
+++ b/engine/python2/engine.py
@@ -66,6 +66,17 @@ printerr = AnthyPrefs.printerr
 ANTHY_CONFIG_PATH = get_userhome() + '/.anthy' if config.ANTHY_PC == 'anthy' \
     else GLib.get_user_config_dir() + '/anthy';
 
+# Shift, Alt and Super keys
+ANTHY_NO_OUTPUT_MODIFIERS = (
+    IBus.ModifierType.CONTROL_MASK |
+    IBus.ModifierType.MOD1_MASK |
+    IBus.ModifierType.MOD4_MASK
+)
+ANTHY_SHORTCUT_MODIFIERS = (
+    ANTHY_NO_OUTPUT_MODIFIERS |
+    IBus.ModifierType.SHIFT_MASK
+)
+
 INPUT_MODE_HIRAGANA, \
 INPUT_MODE_KATAKANA, \
 INPUT_MODE_HALF_WIDTH_KATAKANA, \
@@ -1844,17 +1855,14 @@ class Engine(IBus.EngineSimple):
         def T2():
             return self.__thumb.get_t2()
 
-        state = state & (IBus.ModifierType.SHIFT_MASK |
-                         IBus.ModifierType.CONTROL_MASK |
-                         IBus.ModifierType.MOD1_MASK |
-                         IBus.ModifierType.MOD4_MASK |
-                         IBus.ModifierType.RELEASE_MASK)
+        is_press = (state & IBus.ModifierType.RELEASE_MASK) == 0
+        state &= ANTHY_SHORTCUT_MODIFIERS
 
         if keyval in KP_Table and self.__prefs.get_value('common',
                                                          'ten-key-mode'):
             keyval = KP_Table[keyval]
 
-        if state & IBus.ModifierType.RELEASE_MASK:
+        if not is_press:
             if keyval == self._MM:
                 if stop():
                     insert(self.__thumb.get_char(self._MM)[self._SS])
@@ -1915,15 +1923,14 @@ class Engine(IBus.EngineSimple):
                     cmd_exec([0, RS(), LS()][self._SS])
                 if cmd_exec(keyval, state):
                     return True
-                elif 0x21 <= keyval <= 0x7e and state & \
-                        (IBus.ModifierType.CONTROL_MASK |
-                         IBus.ModifierType.MOD1_MASK |
-                         IBus.ModifierType.MOD4_MASK) == 0:
+                is_alphabet_key = 0x21 <= keyval <= 0x7e and state & ANTHY_NO_OUTPUT_MODIFIERS == 0
+                if is_alphabet_key:
                     if state & IBus.ModifierType.SHIFT_MASK:
                         insert(self.__thumb.get_shift_char(keyval, unichr(keyval)))
                     elif self._SS == 0:
                         insert(unichr(keyval))
                 else:
+                    # when waiting for commit, eat any key press for a any control character (e.g. Enter, PgUp, PgDn)
                     if not self.__preedit_ja_string.is_empty():
                         return True
                     return False
@@ -1940,10 +1947,7 @@ class Engine(IBus.EngineSimple):
 
         is_press = (state & IBus.ModifierType.RELEASE_MASK) == 0
 
-        state = state & (IBus.ModifierType.SHIFT_MASK |
-                         IBus.ModifierType.CONTROL_MASK |
-                         IBus.ModifierType.MOD1_MASK |
-                         IBus.ModifierType.MOD4_MASK)
+        state &= ANTHY_SHORTCUT_MODIFIERS
 
         # ignore key release events
         if not is_press:

--- a/engine/python2/engine.py
+++ b/engine/python2/engine.py
@@ -1923,14 +1923,14 @@ class Engine(IBus.EngineSimple):
                     cmd_exec([0, RS(), LS()][self._SS])
                 if cmd_exec(keyval, state):
                     return True
-                is_alphabet_key = 0x21 <= keyval <= 0x7e and state & ANTHY_NO_OUTPUT_MODIFIERS == 0
-                if is_alphabet_key:
+                if state & ANTHY_NO_OUTPUT_MODIFIERS:
+                    return False
+                if 0x21 <= keyval <= 0x7e:
                     if state & IBus.ModifierType.SHIFT_MASK:
                         insert(self.__thumb.get_shift_char(keyval, unichr(keyval)))
                     elif self._SS == 0:
                         insert(unichr(keyval))
                 else:
-                    # when waiting for commit, eat any key press for a any control character (e.g. Enter, PgUp, PgDn)
                     if not self.__preedit_ja_string.is_empty():
                         return True
                     return False

--- a/engine/python3/engine.py
+++ b/engine/python3/engine.py
@@ -1850,6 +1850,7 @@ class Engine(IBus.EngineSimple):
         state = state & (IBus.ModifierType.SHIFT_MASK |
                          IBus.ModifierType.CONTROL_MASK |
                          IBus.ModifierType.MOD1_MASK |
+                         IBus.ModifierType.MOD4_MASK |
                          IBus.ModifierType.RELEASE_MASK)
 
         if keyval in KP_Table and self.__prefs.get_value('common',
@@ -1918,7 +1919,9 @@ class Engine(IBus.EngineSimple):
                 if cmd_exec(keyval, state):
                     return True
                 elif 0x21 <= keyval <= 0x7e and state & \
-                        (IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.MOD1_MASK) == 0:
+                        (IBus.ModifierType.CONTROL_MASK | \
+                         IBus.ModifierType.MOD1_MASK | \
+                         IBus.ModifierType.MOD4_MASK) == 0:
                     if state & IBus.ModifierType.SHIFT_MASK:
                         insert(self.__thumb.get_shift_char(keyval, chr(keyval)))
                     elif self._SS == 0:

--- a/engine/python3/engine.py
+++ b/engine/python3/engine.py
@@ -1945,8 +1945,8 @@ class Engine(IBus.EngineSimple):
                 if cmd_exec(keyval, state):
                     return True
                 elif 0x21 <= keyval <= 0x7e and state & \
-                        (IBus.ModifierType.CONTROL_MASK | \
-                         IBus.ModifierType.MOD1_MASK | \
+                        (IBus.ModifierType.CONTROL_MASK |
+                         IBus.ModifierType.MOD1_MASK |
                          IBus.ModifierType.MOD4_MASK) == 0:
                     if state & IBus.ModifierType.SHIFT_MASK:
                         insert(self.__thumb.get_shift_char(keyval, chr(keyval)))

--- a/engine/python3/engine.py
+++ b/engine/python3/engine.py
@@ -1952,14 +1952,14 @@ class Engine(IBus.EngineSimple):
                     cmd_exec([0, RS(), LS()][self._SS])
                 if cmd_exec(keyval, state):
                     return True
-                is_alphabet_key = 0x21 <= keyval <= 0x7e and state & ANTHY_NO_OUTPUT_MODIFIERS == 0
-                if is_alphabet_key:
+                if state & ANTHY_NO_OUTPUT_MODIFIERS:
+                    return False
+                if 0x21 <= keyval <= 0x7e:
                     if state & IBus.ModifierType.SHIFT_MASK:
                         insert(self.__thumb.get_shift_char(keyval, chr(keyval)))
                     elif self._SS == 0:
                         insert(chr(keyval))
                 else:
-                    # when waiting for commit, eat any key press for a any control character (e.g. Enter, PgUp, PgDn)
                     if not self.__preedit_ja_string.is_empty():
                         return True
                     return False

--- a/engine/python3/engine.py
+++ b/engine/python3/engine.py
@@ -67,6 +67,17 @@ printerr = AnthyPrefs.printerr
 ANTHY_CONFIG_PATH = get_userhome() + '/.anthy' if config.ANTHY_PC == 'anthy' \
     else GLib.get_user_config_dir() + '/anthy';
 
+# Shift, Alt and Super keys
+ANTHY_NO_OUTPUT_MODIFIERS = (
+    IBus.ModifierType.CONTROL_MASK |
+    IBus.ModifierType.MOD1_MASK |
+    IBus.ModifierType.MOD4_MASK
+)
+ANTHY_SHORTCUT_MODIFIERS = (
+    ANTHY_NO_OUTPUT_MODIFIERS |
+    IBus.ModifierType.SHIFT_MASK
+)
+
 INPUT_MODE_HIRAGANA, \
 INPUT_MODE_KATAKANA, \
 INPUT_MODE_HALF_WIDTH_KATAKANA, \
@@ -1873,17 +1884,14 @@ class Engine(IBus.EngineSimple):
         def T2():
             return self.__thumb.get_t2()
 
-        state = state & (IBus.ModifierType.SHIFT_MASK |
-                         IBus.ModifierType.CONTROL_MASK |
-                         IBus.ModifierType.MOD1_MASK |
-                         IBus.ModifierType.MOD4_MASK |
-                         IBus.ModifierType.RELEASE_MASK)
+        is_press = (state & IBus.ModifierType.RELEASE_MASK) == 0
+        state &= ANTHY_SHORTCUT_MODIFIERS
 
         if keyval in KP_Table and self.__prefs.get_value('common',
                                                          'ten-key-mode'):
             keyval = KP_Table[keyval]
 
-        if state & IBus.ModifierType.RELEASE_MASK:
+        if not is_press:
             if keyval == self._MM:
                 if stop():
                     insert(self.__thumb.get_char(self._MM)[self._SS])
@@ -1944,15 +1952,14 @@ class Engine(IBus.EngineSimple):
                     cmd_exec([0, RS(), LS()][self._SS])
                 if cmd_exec(keyval, state):
                     return True
-                elif 0x21 <= keyval <= 0x7e and state & \
-                        (IBus.ModifierType.CONTROL_MASK |
-                         IBus.ModifierType.MOD1_MASK |
-                         IBus.ModifierType.MOD4_MASK) == 0:
+                is_alphabet_key = 0x21 <= keyval <= 0x7e and state & ANTHY_NO_OUTPUT_MODIFIERS == 0
+                if is_alphabet_key:
                     if state & IBus.ModifierType.SHIFT_MASK:
                         insert(self.__thumb.get_shift_char(keyval, chr(keyval)))
                     elif self._SS == 0:
                         insert(chr(keyval))
                 else:
+                    # when waiting for commit, eat any key press for a any control character (e.g. Enter, PgUp, PgDn)
                     if not self.__preedit_ja_string.is_empty():
                         return True
                     return False
@@ -1969,10 +1976,7 @@ class Engine(IBus.EngineSimple):
 
         is_press = (state & IBus.ModifierType.RELEASE_MASK) == 0
 
-        state = state & (IBus.ModifierType.SHIFT_MASK |
-                         IBus.ModifierType.CONTROL_MASK |
-                         IBus.ModifierType.MOD1_MASK |
-                         IBus.ModifierType.MOD4_MASK)
+        state &= ANTHY_SHORTCUT_MODIFIERS
 
         # ignore key release events
         if not is_press:
@@ -2000,9 +2004,7 @@ class Engine(IBus.EngineSimple):
            state & hex_mod_mask == hex_mod_mask:
             return True
 
-        if state & (IBus.ModifierType.CONTROL_MASK | \
-                    IBus.ModifierType.MOD1_MASK | \
-                    IBus.ModifierType.MOD4_MASK):
+        if state & ANTHY_NO_OUTPUT_MODIFIERS:
             return False
 
         if (IBus.KEY_exclam <= keyval <= IBus.KEY_asciitilde or

--- a/engine/python3/engine.py
+++ b/engine/python3/engine.py
@@ -1876,6 +1876,7 @@ class Engine(IBus.EngineSimple):
         state = state & (IBus.ModifierType.SHIFT_MASK |
                          IBus.ModifierType.CONTROL_MASK |
                          IBus.ModifierType.MOD1_MASK |
+                         IBus.ModifierType.MOD4_MASK |
                          IBus.ModifierType.RELEASE_MASK)
 
         if keyval in KP_Table and self.__prefs.get_value('common',
@@ -1944,7 +1945,9 @@ class Engine(IBus.EngineSimple):
                 if cmd_exec(keyval, state):
                     return True
                 elif 0x21 <= keyval <= 0x7e and state & \
-                        (IBus.ModifierType.CONTROL_MASK | IBus.ModifierType.MOD1_MASK) == 0:
+                        (IBus.ModifierType.CONTROL_MASK | \
+                         IBus.ModifierType.MOD1_MASK | \
+                         IBus.ModifierType.MOD4_MASK) == 0:
                     if state & IBus.ModifierType.SHIFT_MASK:
                         insert(self.__thumb.get_shift_char(keyval, chr(keyval)))
                     elif self._SS == 0:


### PR DESCRIPTION
**Symptom**
Given that:

- typing method is set to thumb shift mode
- input mode is not set to any Latin mode
- a text field is in focus
- Super + Space remains the shortcut for switching to another input method or keyboard layout in IBus

When a user presses Super + Space
Then the user sees a space added to the text field and layout not switched

**Expected**
Given that:

- typing method is set to thumb shift mode
- input mode is not set to any Latin mode
- a text field is in focus
- Super + Space remains the shortcut for switching to another input method or keyboard layout in IBus

When a user presses Super + Space
Then the user sees that Anthy is no longer the active IBus Engine

**Root Cause**
The super key modifier is ignored only in thumb shift mode.

In Thumb Shift Mode (`__process_key_event_thumb()`):

```python
state = state & (IBus.ModifierType.SHIFT_MASK |
                     IBus.ModifierType.CONTROL_MASK |
                     IBus.ModifierType.MOD1_MASK |
                     IBus.ModifierType.RELEASE_MASK)
```

In Romaji or Kana Mode (`__process_key_event_internal2()`):

```python
state = state & (IBus.ModifierType.SHIFT_MASK |
                     IBus.ModifierType.CONTROL_MASK |
                     IBus.ModifierType.MOD1_MASK |
                     IBus.ModifierType.MOD4_MASK)
```

**Solution**
Supplement `MOD4_MASK` to the state usages specific to thumb shift mode.

**Remarks**
Please let me know if there are practices that I should follow.