### PR TITLE
Allow custom Python path for era.t

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -89,7 +89,8 @@ era.stamp:
 	    if ! $(PYTHON) $(srcdir)/era.py --check $(srcdir)/era.t ; then \
 	        rm $(srcdir)/era.t; \
 	        $(PYTHON) $(srcdir)/era.py $(srcdir)/era.t.in \
-                    --output $(builddir)/era.t; \
+                    --output $(builddir)/era.t \
+					|| exit 1; \
 	        echo "Generate era.t"; \
 	    fi; \
 	fi; \

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -86,9 +86,9 @@ era.t: era.stamp
 
 era.stamp:
 	if test -f $(srcdir)/era.t ; then \
-	    if ! $(srcdir)/era.py --check $(srcdir)/era.t ; then \
+	    if ! $(PYTHON) $(srcdir)/era.py --check $(srcdir)/era.t ; then \
 	        rm $(srcdir)/era.t; \
-	        $(srcdir)/era.py $(srcdir)/era.t.in \
+	        $(PYTHON) $(srcdir)/era.py $(srcdir)/era.t.in \
                     --output $(builddir)/era.t; \
 	        echo "Generate era.t"; \
 	    fi; \
@@ -98,9 +98,9 @@ era.stamp:
 
 check:
 	if test -f $(srcdir)/era.t ; then \
-	    $(srcdir)/era.py --check $(srcdir)/era.t; \
+	    $(PYTHON) $(srcdir)/era.py --check $(srcdir)/era.t; \
 	else \
-	    $(srcdir)/era.py --check $(builddir)/era.t; \
+	    $(PYTHON) $(srcdir)/era.py --check $(builddir)/era.t; \
 	fi
 
 install-data-hook:


### PR DESCRIPTION
The new `era.py` is used as an interpreted script in the data makefile. Since `era.py` contains `#!/usr/bin/python3`, ibus-anthy 1.5.18 does not build in environments that are not FHS-compliant (`python3` is not under `/usr/bin`).

To avoid regression with existing non-FHS build scripts, the existing variable `$(PYTHON)` is supplemented here for calls upon `era.py`.